### PR TITLE
Fix JSON namespace in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You'll need to create lib/secret.json that contains your credentials for interac
 
 ```
 {
-  "twitter_keys": {
+  "twitter": {
     "consumer_key": "",
     "consumer_secret": "",
     "callbackURL": ""


### PR DESCRIPTION
The code wants the JSON object to have a top-level object called `"twitter"`, not `"twitterKeys"`, so I've made that correction here in the readme.
